### PR TITLE
support initialize saml with raw string certificate

### DIFF
--- a/authnresponse.go
+++ b/authnresponse.go
@@ -76,9 +76,16 @@ func (r *Response) Validate(s *ServiceProviderSettings) error {
 		return errors.New("subject recipient mismatch, expected: " + s.AssertionConsumerServiceURL + " not " + r.Assertion.Subject.SubjectConfirmation.SubjectConfirmationData.Recipient)
 	}
 
-	err := VerifyResponseSignature(r.originalString, s.IDPPublicCertPath)
-	if err != nil {
-		return err
+	if s.RawIDPPublicCert != "" {
+		err := VerifyResponseSignatureCert(r.originalString, s.RawIDPPublicCert)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := VerifyResponseSignature(r.originalString, s.IDPPublicCertPath)
+		if err != nil {
+			return err
+		}
 	}
 
 	//CHECK TIMES

--- a/loadcertificate.go
+++ b/loadcertificate.go
@@ -14,10 +14,15 @@ func loadCertificate(certPath string) (string, error) {
 	}
 	cert := string(b)
 
+	return cleanCertificate(cert), nil
+}
+
+// cleanCertificate clean given certificate
+func cleanCertificate(cert string) string {
 	re := regexp.MustCompile("---(.*)CERTIFICATE(.*)---")
 	cert = re.ReplaceAllString(cert, "")
 	cert = strings.Trim(cert, " \n")
 	cert = strings.Replace(cert, "\n", "", -1)
 
-	return cert, nil
+	return cert
 }

--- a/saml.go
+++ b/saml.go
@@ -7,10 +7,13 @@ import "errors"
 // then configure multiple instances of this module
 type ServiceProviderSettings struct {
 	PublicCertPath              string
+	RawPublicCert               string
 	PrivateKeyPath              string
+	RawPrivateKey               string
 	IDPSSOURL                   string
 	IDPSSODescriptorURL         string
 	IDPPublicCertPath           string
+	RawIDPPublicCert            string
 	AssertionConsumerServiceURL string
 	SPSignRequest               bool
 
@@ -31,20 +34,32 @@ func (s *ServiceProviderSettings) Init() error {
 
 	var err error
 	if s.SPSignRequest {
-		s.publicCert, err = loadCertificate(s.PublicCertPath)
-		if err != nil {
-			return err
+		if s.RawPublicCert != "" {
+			s.publicCert = cleanCertificate(s.RawPublicCert)
+		} else {
+			s.publicCert, err = loadCertificate(s.PublicCertPath)
+			if err != nil {
+				return err
+			}
 		}
 
-		s.privateKey, err = loadCertificate(s.PrivateKeyPath)
-		if err != nil {
-			return err
+		if s.RawPrivateKey != "" {
+			s.privateKey = cleanCertificate(s.RawPrivateKey)
+		} else {
+			s.privateKey, err = loadCertificate(s.PrivateKeyPath)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
-	s.iDPPublicCert, err = loadCertificate(s.IDPPublicCertPath)
-	if err != nil {
-		return err
+	if s.RawIDPPublicCert != "" {
+		s.iDPPublicCert = cleanCertificate(s.RawIDPPublicCert)
+	} else {
+		s.iDPPublicCert, err = loadCertificate(s.IDPPublicCertPath)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/xmlsec.go
+++ b/xmlsec.go
@@ -79,8 +79,8 @@ func VerifyResponseSignatureCert(xml string, cert string) error {
 // VerifyRequestSignature verify signature of a SAML 2.0 AuthnRequest document
 // `publicCertPath` must be a path on the filesystem, xmlsec1 is run out of process
 // through `exec`
-func VerifyRequestSignature(xml string, publicCert string) error {
-	return verify(xml, publicCert, xmlRequestID)
+func VerifyRequestSignature(xml string, publicCertPath string) error {
+	return verify(xml, publicCertPath, xmlRequestID)
 }
 
 func verify(xml string, publicCertPath string, id string) error {

--- a/xmlsec.go
+++ b/xmlsec.go
@@ -69,11 +69,18 @@ func VerifyResponseSignature(xml string, publicCertPath string) error {
 	return verify(xml, publicCertPath, xmlResponseID)
 }
 
+// VerifyResponseSignatureCert verify signature of a SAML 2.0 Response document
+// `cert` must be the raw cert, xmlsec1 is run out of process
+// through `exec`
+func VerifyResponseSignatureCert(xml string, cert string) error {
+	return verifyCert(xml, cert, xmlResponseID)
+}
+
 // VerifyRequestSignature verify signature of a SAML 2.0 AuthnRequest document
 // `publicCertPath` must be a path on the filesystem, xmlsec1 is run out of process
 // through `exec`
-func VerifyRequestSignature(xml string, publicCertPath string) error {
-	return verify(xml, publicCertPath, xmlRequestID)
+func VerifyRequestSignature(xml string, publicCert string) error {
+	return verify(xml, publicCert, xmlRequestID)
 }
 
 func verify(xml string, publicCertPath string, id string) error {
@@ -92,6 +99,42 @@ func verify(xml string, publicCertPath string, id string) error {
 	if err != nil {
 		return errors.New("error verifing signature: " + err.Error())
 	}
+	return nil
+}
+
+func verifyCert(xml string, cert string, id string) error {
+	// Write saml to temporary file
+	samlXmlsecInput, err := os.CreateTemp(os.TempDir(), "tmpgs")
+	if err != nil {
+		return err
+	}
+	defer deleteTempFile(samlXmlsecInput.Name())
+
+	_, err = samlXmlsecInput.Write([]byte(xml))
+	if err != nil {
+		return err
+	}
+	samlXmlsecInput.Close()
+
+	// Write cert to temporary file
+	certFile, err := os.CreateTemp(os.TempDir(), "tmpcert_*.cert")
+	if err != nil {
+		return err
+	}
+	defer deleteTempFile(certFile.Name())
+
+	_, err = certFile.Write([]byte(cert))
+	if err != nil {
+		return err
+	}
+	certFile.Close()
+
+	// Call xmlsec1 command with cert data
+	_, err = exec.Command("xmlsec1", "--verify", "--pubkey-cert-pem", certFile.Name(), "--id-attr:ID", id, samlXmlsecInput.Name()).CombinedOutput()
+	if err != nil {
+		return errors.New("error verifying signature: " + err.Error())
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Added support to init the saml with the certificates as string and not by given path.
If wanted to init by path to certificate use the `PublicCertPath`, `PrivateKeyPath` & `IDPPublicCertPath` fields
if wanted to init by the actual certificate use the `RawPublicCert`, `RawPrivateKey` & `RawIDPPublicCert` fields

related Vorlon-Inc/etc#1475